### PR TITLE
FEATURE: Add lifetimeThreshold for updating session metadata

### DIFF
--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -124,7 +124,17 @@ class Session implements CookieEnabledInterface
     /**
      * @var integer
      */
+    protected $lifetimeThreshold;
+
+    /**
+     * @var integer
+     */
     protected $lastActivityTimestamp;
+
+    /**
+     * @var SessionMetadata|null
+     */
+    protected $previousSessionMetadata;
 
     /**
      * @var array
@@ -242,6 +252,7 @@ class Session implements CookieEnabledInterface
         $this->garbageCollectionProbability = $settings['session']['garbageCollection']['probability'];
         $this->garbageCollectionMaximumPerRun = $settings['session']['garbageCollection']['maximumPerRun'];
         $this->inactivityTimeout = (integer)$settings['session']['inactivityTimeout'];
+        $this->lifetimeThreshold = (integer)$settings['session']['lifetimeThreshold'];
     }
 
     /**
@@ -348,6 +359,7 @@ class Session implements CookieEnabledInterface
         if ($sessionMetaData === false) {
             return false;
         }
+        $this->previousSessionMetadata = SessionMetadata::fromArray($sessionMetaData);
         $this->lastActivityTimestamp = $sessionMetaData['lastActivityTimestamp'];
         $this->storageIdentifier = $sessionMetaData['storageIdentifier'];
         $this->tags = $sessionMetaData['tags'];
@@ -712,7 +724,7 @@ class Session implements CookieEnabledInterface
     {
         $lastActivitySecondsAgo = $this->now - $this->lastActivityTimestamp;
         $expired = false;
-        if ($this->inactivityTimeout !== 0 && $lastActivitySecondsAgo > $this->inactivityTimeout) {
+        if ($this->inactivityTimeout !== 0 && $lastActivitySecondsAgo > ($this->inactivityTimeout + $this->lifetimeThreshold)) {
             $this->started = true;
             $this->sessionIdentifier = $this->sessionCookie->getValue();
             $this->destroy(sprintf('Session %s was inactive for %s seconds, more than the configured timeout of %s seconds.', $this->sessionIdentifier, $lastActivitySecondsAgo, $this->inactivityTimeout));
@@ -767,11 +779,16 @@ class Session implements CookieEnabledInterface
      */
     protected function writeSessionMetaDataCacheEntry()
     {
-        $sessionInfo = [
-            'lastActivityTimestamp' => $this->lastActivityTimestamp,
-            'storageIdentifier' => $this->storageIdentifier,
-            'tags' => $this->tags
-        ];
+
+        $sessionMetadata = new SessionMetadata(
+            $this->lastActivityTimestamp,
+            $this->storageIdentifier,
+           $this->tags
+        );
+
+        if ($this->previousSessionMetadata && $sessionMetadata->equalsWithinLastActivityThreshold($this->previousSessionMetadata, $this->lifetimeThreshold)) {
+            return;
+        }
 
         $tagsForCacheEntry = array_map(function ($tag) {
             return Session::TAG_PREFIX . $tag;
@@ -779,7 +796,7 @@ class Session implements CookieEnabledInterface
         $tagsForCacheEntry[] = $this->sessionIdentifier;
         $tagsForCacheEntry[] = 'session';
 
-        $this->metaDataCache->set($this->sessionIdentifier, $sessionInfo, $tagsForCacheEntry, 0);
+        $this->metaDataCache->set($this->sessionIdentifier, $sessionMetadata->jsonSerialize(), $tagsForCacheEntry, 0);
     }
 
     /**

--- a/Neos.Flow/Classes/Session/SessionMetadata.php
+++ b/Neos.Flow/Classes/Session/SessionMetadata.php
@@ -1,0 +1,66 @@
+<?php
+namespace Neos\Flow\Session;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+/**
+ * A value object representing session metadata
+ */
+class SessionMetadata implements \JsonSerializable
+{
+    public function __construct(
+       protected int $lastActivityTimestamp,
+       protected string $storageIdentifier,
+       protected array $tags,
+    ) {}
+
+    public function getLastActivityTimestamp(): int
+    {
+        return $this->lastActivityTimestamp;
+    }
+
+    public function getStorageIdentifier(): string
+    {
+        return $this->storageIdentifier;
+    }
+
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
+    public function equalsWithinLastActivityThreshold(SessionMetadata $previous, int $threshold): bool
+    {
+        $LastActivityDifference = $this->lastActivityTimestamp - $previous->lastActivityTimestamp;
+        return
+            $LastActivityDifference <= $threshold
+            && $this->storageIdentifier == $previous->storageIdentifier
+            && $this->tags == $previous->tags;
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new static(
+            $data['lastActivityTimestamp'],
+            $data['storageIdentifier'],
+            $data['tags'],
+        );
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'lastActivityTimestamp' => $this->lastActivityTimestamp,
+            'storageIdentifier' => $this->storageIdentifier,
+            'tags' => $this->tags
+        ];
+    }
+}

--- a/Neos.Flow/Configuration/Settings.Session.yaml
+++ b/Neos.Flow/Configuration/Settings.Session.yaml
@@ -11,6 +11,11 @@ Neos:
       # automatically.
       inactivityTimeout: 3600
 
+      # A threshold for updating the lifetime, unless the date changed at lest
+      # the specified seconds the session metadata including last activity will
+      # not be updated in the Session_Metadata cache.
+      lifetimeThreshold: 60
+
       # A specific name for the session, used in the session cookie.
       # The session name must be alphanumerical and must contain at least one
       # character – not only numbers.

--- a/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.session.schema.yaml
+++ b/Neos.Flow/Resources/Private/Schema/Settings/Neos.Flow.session.schema.yaml
@@ -2,6 +2,7 @@ type: dictionary
 additionalProperties: false
 properties:
   'inactivityTimeout': { type: integer, required: true }
+  'lifetimeThreshold': { type: integer, required: true }
   'name': { type: [string, 'null'], required: true }
   'garbageCollection':
     type: dictionary

--- a/Neos.Flow/Tests/Unit/Session/SessionMetadataTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionMetadataTest.php
@@ -1,0 +1,166 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Session;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Session\SessionMetadata;
+use Neos\Flow\Tests\UnitTestCase;
+
+/**
+ * Unit tests for the Flow Session Metadata implementation
+ */
+class SessionMetadataTest extends UnitTestCase
+{
+
+    /**
+     * @test
+     */
+    public function serializationCreatesClassicFormat(): void
+    {
+        $sessionMetadata = new SessionMetadata(
+            123,
+            'a_string',
+            ["foo", "bar"]
+        );
+
+        $this->assertEquals(
+            [
+                'lastActivityTimestamp' => 123,
+                'storageIdentifier' => 'a_string',
+                'tags' => ["foo", "bar"]
+            ],
+            $sessionMetadata->jsonSerialize()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function fromArrayCreatesClassicFormat(): void
+    {
+        $sessionMetadata = SessionMetadata::fromArray(
+            [
+                'lastActivityTimestamp' => 123,
+                'storageIdentifier' => 'a_string',
+                'tags' => ["foo", "bar"]
+            ]
+        );
+        $this->assertEquals(123, $sessionMetadata->getLastActivityTimestamp());
+        $this->assertEquals('a_string', $sessionMetadata->getStorageIdentifier());
+        $this->assertEquals(["foo", "bar"], $sessionMetadata->getTags());
+    }
+
+    public function equalsWithinLastActivityThresholdHandlesLifetimeDataProvider(): array
+    {
+        return [
+            [1000, 1051, false],
+            [1000, 1050, true],
+            [1000, 1049, true],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider equalsWithinLastActivityThresholdHandlesLifetimeDataProvider
+     */
+    public function equalsWithinLastActivityThresholdHandlesLifetime(int $previousTimestamp, int $currentTimestamp, bool $expectation): void
+    {
+        $previousMetadata = SessionMetadata::fromArray(
+            [
+                'lastActivityTimestamp' => $previousTimestamp,
+                'storageIdentifier' => 'a_string',
+                'tags' => ["foo", "bar"]
+            ]
+        );
+
+        $sessionMetadata = SessionMetadata::fromArray(
+            [
+                'lastActivityTimestamp' => $currentTimestamp,
+                'storageIdentifier' => 'a_string',
+                'tags' => ["foo", "bar"]
+            ]
+        );
+
+        $this->assertEquals($expectation, $sessionMetadata->equalsWithinLastActivityThreshold($previousMetadata, 50));
+    }
+
+    public function equalsWithinLastActivityThresholdDetectsStorageIdChangesDataProvider(): array
+    {
+        return [
+            ['foo', 'bar', false],
+            ['foo', '', false],
+            ['', 'bar', false],
+            ['foo', 'foo', true],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider equalsWithinLastActivityThresholdDetectsStorageIdChangesDataProvider
+     */
+    public function equalsWithinLastActivityThresholdDetectsStorageIdChanges(string $previousId, string $currentId, bool $expectation): void
+    {
+        $previousMetadata = SessionMetadata::fromArray(
+            [
+                'lastActivityTimestamp' => 1000,
+                'storageIdentifier' => $previousId,
+                'tags' => ["foo", "bar"]
+            ]
+        );
+
+        $sessionMetadata = SessionMetadata::fromArray(
+            [
+                'lastActivityTimestamp' => 1000,
+                'storageIdentifier' => $currentId,
+                'tags' => ["foo", "bar"]
+            ]
+        );
+
+        $this->assertEquals($expectation, $sessionMetadata->equalsWithinLastActivityThreshold($previousMetadata, 50));
+    }
+
+
+    public function equalsWithinLastActivityThresholdDetectsTagChangesDataProvider(): array
+    {
+        return [
+            [["foo"], ["foo", "bar"], false],
+            [["foo", "bar"], ["foo"], false],
+            [[], ["foo", "bar"], false],
+            [[], [], true],
+            [["foo", "bar"], ["foo", "bar"], true],
+        ];
+    }
+    /**
+     * @test
+     * @dataProvider equalsWithinLastActivityThresholdDetectsTagChangesDataProvider
+     */
+    public function equalsWithinLastActivityThresholdDetectsTagChanges(array $previousTags, array $currentTags, bool $expectation): void
+    {
+        $previousMetadata = SessionMetadata::fromArray(
+            [
+                'lastActivityTimestamp' => 1000,
+                'storageIdentifier' => 'a_string',
+                'tags' => $previousTags
+            ]
+        );
+
+        $sessionMetadata = SessionMetadata::fromArray(
+            [
+                'lastActivityTimestamp' => 1000,
+                'storageIdentifier' => 'a_string',
+                'tags' => $currentTags
+            ]
+        );
+
+        $this->assertEquals($expectation, $sessionMetadata->equalsWithinLastActivityThreshold($previousMetadata, 50));
+    }
+
+}

--- a/Neos.Flow/Tests/Unit/Session/SessionTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionTest.php
@@ -73,6 +73,7 @@ class SessionTest extends UnitTestCase
     protected $settings = [
         'session' => [
             'inactivityTimeout' => 3600,
+            'lifetimeThreshold' => 60,
             'name' => 'Neos_Flow_Session',
             'garbageCollection' => [
                 'probability' => 1,
@@ -1123,6 +1124,7 @@ class SessionTest extends UnitTestCase
     {
         $settings = $this->settings;
         $settings['session']['inactivityTimeout'] = 1000;
+        $settings['session']['lifetimeThreshold'] = 60;
         $settings['session']['garbageCollection']['probability'] = 0;
         $settings['session']['garbageCollection']['maximumPerRun'] = 5;
 


### PR DESCRIPTION
This will prevent that the session metadata cache ie written permanently. The new implementation will ensure that the metadata is updated when values change and the age difference is above the threshold.

The threshold can be configured with the setting:

```
Neos:
  Flow:
    session:
      # A threshold for updating the lifetime, unless the date changed at lest
      # the specified seconds the session metadata including last activity will
      # not be updated in the Session_Metadata cache.
      lifetimeThreshold: 60
```

<!-- 
    Thanks for your contribution, we appreciate it!

    The first section should explain briefly what is changed. 
    Some examples are always nice to showcase the use. 
    The content will be used in the change-logs and addresses 
    developers working with Neos.

    If there are issues regarding the topic of your PR link 
    them here as `related:` or `resolved:`
-->

**Upgrade instructions**

<!-- 
    Add upgrade instructions for breaking changes. 
    Explain who is affected, what has to be adjusted  
-->

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
