### PR TITLE
TASK: Avoid overwriting unchanged session data

### DIFF
--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -362,7 +362,7 @@ class Session implements CookieEnabledInterface
         if ($this->started === false && $this->canBeResumed()) {
             $this->started = true;
 
-            $sessionObjects = $this->sessionStorage->get($this->storageIdentifier . md5('Neos_Flow_Object_ObjectManager'));
+            $sessionObjects = $this->sessionStorage->retrieve($this->storageIdentifier . md5('Neos_Flow_Object_ObjectManager'));
             if (is_array($sessionObjects)) {
                 foreach ($sessionObjects as $object) {
                     if ($object instanceof ProxyInterface) {
@@ -376,7 +376,7 @@ class Session implements CookieEnabledInterface
             } else {
                 // Fallback for some malformed session data, if it is no array but something else.
                 // In this case, we reset all session objects (graceful degradation).
-                $this->sessionStorage->set($this->storageIdentifier . md5('Neos_Flow_Object_ObjectManager'), [], [$this->storageIdentifier], 0);
+                $this->sessionStorage->store($this->storageIdentifier . md5('Neos_Flow_Object_ObjectManager'), [], [$this->storageIdentifier], 0);
             }
 
             $lastActivitySecondsAgo = ($this->now - $this->lastActivityTimestamp);
@@ -438,7 +438,7 @@ class Session implements CookieEnabledInterface
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('Tried to get session data, but the session has not been started yet.', 1351162255);
         }
-        return $this->sessionStorage->get($this->storageIdentifier . md5($key));
+        return $this->sessionStorage->retrieve($this->storageIdentifier . md5($key));
     }
 
     /**
@@ -474,7 +474,7 @@ class Session implements CookieEnabledInterface
         if (is_resource($data)) {
             throw new Exception\DataNotSerializableException('The given data cannot be stored in a session, because it is of type "' . gettype($data) . '".', 1351162262);
         }
-        $this->sessionStorage->set($this->storageIdentifier . md5($key), $data, [$this->storageIdentifier], 0);
+        $this->sessionStorage->store($this->storageIdentifier . md5($key), $data, [$this->storageIdentifier], 0);
     }
 
     /**

--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -72,9 +72,9 @@ class Session implements CookieEnabledInterface
      * Storage cache for this session
      *
      * @Flow\Inject
-     * @var VariableFrontend
+     * @var SessionStorage
      */
-    protected $storageCache;
+    protected $sessionStorage;
 
     /**
      * @var string
@@ -264,9 +264,6 @@ class Session implements CookieEnabledInterface
         if (!$this->metaDataCache->getBackend() instanceof IterableBackendInterface) {
             throw new InvalidBackendException(sprintf('The session meta data cache must provide a backend implementing the IterableBackendInterface, but the given backend "%s" does not implement it.', get_class($this->metaDataCache->getBackend())), 1370964557);
         }
-        if (!$this->storageCache->getBackend() instanceof IterableBackendInterface) {
-            throw new InvalidBackendException(sprintf('The session storage cache must provide a backend implementing the IterableBackendInterface, but the given backend "%s" does not implement it.', get_class($this->storageCache->getBackend())), 1370964558);
-        }
     }
 
     /**
@@ -365,7 +362,7 @@ class Session implements CookieEnabledInterface
         if ($this->started === false && $this->canBeResumed()) {
             $this->started = true;
 
-            $sessionObjects = $this->storageCache->get($this->storageIdentifier . md5('Neos_Flow_Object_ObjectManager'));
+            $sessionObjects = $this->sessionStorage->get($this->storageIdentifier . md5('Neos_Flow_Object_ObjectManager'));
             if (is_array($sessionObjects)) {
                 foreach ($sessionObjects as $object) {
                     if ($object instanceof ProxyInterface) {
@@ -379,7 +376,7 @@ class Session implements CookieEnabledInterface
             } else {
                 // Fallback for some malformed session data, if it is no array but something else.
                 // In this case, we reset all session objects (graceful degradation).
-                $this->storageCache->set($this->storageIdentifier . md5('Neos_Flow_Object_ObjectManager'), [], [$this->storageIdentifier], 0);
+                $this->sessionStorage->set($this->storageIdentifier . md5('Neos_Flow_Object_ObjectManager'), [], [$this->storageIdentifier], 0);
             }
 
             $lastActivitySecondsAgo = ($this->now - $this->lastActivityTimestamp);
@@ -441,7 +438,7 @@ class Session implements CookieEnabledInterface
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('Tried to get session data, but the session has not been started yet.', 1351162255);
         }
-        return $this->storageCache->get($this->storageIdentifier . md5($key));
+        return $this->sessionStorage->get($this->storageIdentifier . md5($key));
     }
 
     /**
@@ -456,7 +453,7 @@ class Session implements CookieEnabledInterface
         if ($this->started !== true) {
             throw new Exception\SessionNotStartedException('Tried to check a session data entry, but the session has not been started yet.', 1352488661);
         }
-        return $this->storageCache->has($this->storageIdentifier . md5($key));
+        return $this->sessionStorage->has($this->storageIdentifier . md5($key));
     }
 
     /**
@@ -477,7 +474,7 @@ class Session implements CookieEnabledInterface
         if (is_resource($data)) {
             throw new Exception\DataNotSerializableException('The given data cannot be stored in a session, because it is of type "' . gettype($data) . '".', 1351162262);
         }
-        $this->storageCache->set($this->storageIdentifier . md5($key), $data, [$this->storageIdentifier], 0);
+        $this->sessionStorage->set($this->storageIdentifier . md5($key), $data, [$this->storageIdentifier], 0);
     }
 
     /**
@@ -609,7 +606,7 @@ class Session implements CookieEnabledInterface
         }
 
         $this->removeSessionMetaDataCacheEntry($this->sessionIdentifier);
-        $this->storageCache->flushByTag($this->storageIdentifier);
+        $this->sessionStorage->flushByTag($this->storageIdentifier);
         $this->started = false;
         $this->sessionIdentifier = null;
         $this->storageIdentifier = null;
@@ -653,7 +650,7 @@ class Session implements CookieEnabledInterface
             $lastActivitySecondsAgo = $this->now - $sessionInfo['lastActivityTimestamp'];
             if ($lastActivitySecondsAgo > $this->inactivityTimeout) {
                 if ($sessionInfo['storageIdentifier'] !== null) {
-                    $this->storageCache->flushByTag($sessionInfo['storageIdentifier']);
+                    $this->sessionStorage->flushByTag($sessionInfo['storageIdentifier']);
                     $sessionRemovalCount++;
                 }
                 $this->metaDataCache->remove($sessionIdentifier);

--- a/Neos.Flow/Classes/Session/SessionStorage.php
+++ b/Neos.Flow/Classes/Session/SessionStorage.php
@@ -15,53 +15,83 @@ namespace Neos\Flow\Session;
 
 use Neos\Cache\Backend\IterableBackendInterface;
 use Neos\Cache\Exception\InvalidBackendException;
-use Neos\Cache\Frontend\VariableFrontend;
+use Neos\Cache\Frontend\StringFrontend;
 use Neos\Flow\Annotations as Flow;
 
 class SessionStorage
 {
     /**
-     * Storage cache for this session
+     * Storage cache
      *
      * @Flow\Inject
-     * @var VariableFrontend
+     * @var StringFrontend
      */
     protected $storageCache;
 
     /**
-     * @return void
-     * @throws InvalidBackendException
+     * @var string[]
      */
+    protected $runtimeStorageCache = [];
+
+    /**
+     * @var bool
+     */
+    protected $useIgBinary;
+
     public function initializeObject()
     {
         if (!$this->storageCache->getBackend() instanceof IterableBackendInterface) {
             throw new InvalidBackendException(sprintf('The session storage cache must provide a backend implementing the IterableBackendInterface, but the given backend "%s" does not implement it.', get_class($this->storageCache->getBackend())), 1370964558);
         }
+        $this->useIgBinary = extension_loaded('igbinary');
     }
 
-    public function get(string $entryIdentifier)
+    public function retrieve(string $entryIdentifier)
     {
-        return $this->storageCache->get($entryIdentifier);
+        $serializedResult = $this->retrieveSerializedValue($entryIdentifier);
+        if ($serializedResult === false) {
+            return false;
+        }
+        return ($this->useIgBinary === true) ? igbinary_unserialize($serializedResult) : unserialize($serializedResult);
     }
 
-    public function set(string $entryIdentifier, $variable, array $tags = [], int $lifetime = null)
+    public function store(string $entryIdentifier, $variable, array $tags = [], int $lifetime = null): void
     {
-        return $this->storageCache->set($entryIdentifier, $variable, $tags, $lifetime);
+        $serializedValue = ($this->useIgBinary === true) ? igbinary_serialize($variable) : serialize($variable);
+        $previousSerializedValue = $this->retrieveSerializedValue($entryIdentifier);
+        if ($serializedValue == $previousSerializedValue) {
+            return;
+        }
+        $this->storeSerializedValue($entryIdentifier,$serializedValue,$tags,$lifetime);
+    }
+
+    protected function retrieveSerializedValue(string $entryIdentifier): false|string
+    {
+        if (array_key_exists($entryIdentifier, $this->runtimeStorageCache)) {
+            return $this->runtimeStorageCache[$entryIdentifier];
+        } else {
+            return $this->storageCache->get($entryIdentifier);
+        }
+    }
+
+    protected function storeSerializedValue(string $entryIdentifier, string $variable, array $tags = [], int $lifetime = null): void
+    {
+        $this->runtimeStorageCache[$entryIdentifier] = $variable;
+        $this->storageCache->set($entryIdentifier,$variable,$tags,$lifetime);
     }
 
     public function has(string $entryIdentifier): bool
     {
-        return $this->storageCache->has($entryIdentifier);
+        if (array_key_exists($entryIdentifier, $this->runtimeStorageCache)) {
+            return $this->runtimeStorageCache[$entryIdentifier] !== false;
+        } else {
+            return $this->storageCache->has($entryIdentifier);
+        }
     }
 
     public function flushByTag(string $tag): int
     {
+        $this->runtimeStorageCache = [];
         return $this->storageCache->flushByTag($tag);
     }
-
-    public function flushByTags(array $tags): int
-    {
-        return $this->storageCache->flushByTags($tags);
-    }
-
 }

--- a/Neos.Flow/Classes/Session/SessionStorage.php
+++ b/Neos.Flow/Classes/Session/SessionStorage.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\Flow\Session;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Cache\Backend\IterableBackendInterface;
+use Neos\Cache\Exception\InvalidBackendException;
+use Neos\Cache\Frontend\VariableFrontend;
+use Neos\Flow\Annotations as Flow;
+
+class SessionStorage
+{
+    /**
+     * Storage cache for this session
+     *
+     * @Flow\Inject
+     * @var VariableFrontend
+     */
+    protected $storageCache;
+
+    /**
+     * @return void
+     * @throws InvalidBackendException
+     */
+    public function initializeObject()
+    {
+        if (!$this->storageCache->getBackend() instanceof IterableBackendInterface) {
+            throw new InvalidBackendException(sprintf('The session storage cache must provide a backend implementing the IterableBackendInterface, but the given backend "%s" does not implement it.', get_class($this->storageCache->getBackend())), 1370964558);
+        }
+    }
+
+    public function get(string $entryIdentifier)
+    {
+        return $this->storageCache->get($entryIdentifier);
+    }
+
+    public function set(string $entryIdentifier, $variable, array $tags = [], int $lifetime = null)
+    {
+        return $this->storageCache->set($entryIdentifier, $variable, $tags, $lifetime);
+    }
+
+    public function has(string $entryIdentifier): bool
+    {
+        return $this->storageCache->has($entryIdentifier);
+    }
+
+    public function flushByTag(string $tag): int
+    {
+        return $this->storageCache->flushByTag($tag);
+    }
+
+    public function flushByTags(array $tags): int
+    {
+        return $this->storageCache->flushByTags($tags);
+    }
+
+}

--- a/Neos.Flow/Configuration/Caches.yaml
+++ b/Neos.Flow/Configuration/Caches.yaml
@@ -128,6 +128,7 @@ Flow_Session_MetaData:
   backend: Neos\Cache\Backend\FileBackend
   persistent: true
 Flow_Session_Storage:
+  frontend: Neos\Cache\Frontend\StringFrontend
   backend: Neos\Cache\Backend\FileBackend
   persistent: true
 

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -461,6 +461,9 @@ Neos\Flow\Session\Session:
         arguments:
           1:
             value: Flow_Session_MetaData
+
+Neos\Flow\Session\SessionStorage:
+  properties:
     storageCache:
       object:
         factoryObjectName: Neos\Flow\Cache\CacheManager


### PR DESCRIPTION
Currently the session will always write all session data especially "Neos_Flow_Security_Accounts" and "Neos_Flow_Object_ObjectManager" at the end of each request regardless wether those were changed or not.

This change extracts the storing and retrieving of session data into a separate object that compares the serialized data and only writes informations to the cache that have been changed to avoid unneeded io / network load. To make this possible the session now uses a string cache frontend and handles serialization internally.

**Review instructions**

<!-- 
    If your change is not explained fully by the first section you can 
    add more details here to help the reviewers understand the change.
    We have to understand what you did, why you did it and how we can 
    verify it works correctly and does no harm.
-->

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
