### PR TITLE
FEATURE: Introduce `session:collectgarbage` command and move the garbage collection from session to sessionManager

### DIFF
--- a/Neos.Flow/Classes/Command/SessionCommandController.php
+++ b/Neos.Flow/Classes/Command/SessionCommandController.php
@@ -14,6 +14,7 @@ namespace Neos\Flow\Command;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Cache\CacheManager;
 use Neos\Flow\Cli\CommandController;
+use Neos\Flow\Session\SessionManagerInterface;
 
 /**
  * Command controller for managing sessions
@@ -30,12 +31,26 @@ class SessionCommandController extends CommandController
     protected $cacheManager;
 
     /**
+     * @var SessionManagerInterface
+     */
+    protected $sessionManager;
+
+    /**
      * @param CacheManager $cacheManager
      * @return void
      */
     public function injectCacheManager(CacheManager $cacheManager)
     {
         $this->cacheManager = $cacheManager;
+    }
+
+    /**
+     * @param SessionManagerInterface $sessionManager
+     * @return void
+     */
+    public function injectSessionManager(SessionManagerInterface $sessionManager)
+    {
+        $this->sessionManager = $sessionManager;
     }
 
     /**
@@ -54,6 +69,26 @@ class SessionCommandController extends CommandController
         $this->cacheManager->getCache('Flow_Session_Storage')->flush();
         $this->cacheManager->getCache('Flow_Session_MetaData')->flush();
         $this->outputLine('Destroyed all sessions.');
+        $this->sendAndExit(0);
+    }
+
+    /**
+     * Run garbage collection for sesions.
+     * This command will remove session-data and -metadate of outdated sessions
+     * identified by lastActivityTimestamp being older than inactivityTimeout
+     *
+     * !!! This is usually done automatically after shutdown for the percentage
+     * of requests specified in the setting `Neos.Flow.session.garbageCollection.probability`
+     *
+     * Use this command if you need more direct control over the cleanup intervals.
+     *
+     * @return void
+     * @since 8.2
+     */
+    public function collectGarbageCommand()
+    {
+        $this->sessionManager->collectGarbage();
+        $this->outputLine('Collected session Garbage');
         $this->sendAndExit(0);
     }
 }

--- a/Neos.Flow/Classes/Session/Session.php
+++ b/Neos.Flow/Classes/Session/Session.php
@@ -77,6 +77,13 @@ class Session implements CookieEnabledInterface
     protected $storageCache;
 
     /**
+     * @deprecated will be removed with Flow 9 as this is only needed to avoid breakiness
+     * @Flow\Inject
+     * @var SessionManagerInterface
+     */
+    protected $sessionManager;
+
+    /**
      * @var string
      */
     protected $sessionCookieName;
@@ -135,16 +142,6 @@ class Session implements CookieEnabledInterface
      * @var integer
      */
     protected $now;
-
-    /**
-     * @var float
-     */
-    protected $garbageCollectionProbability;
-
-    /**
-     * @var integer
-     */
-    protected $garbageCollectionMaximumPerRun;
 
     /**
      * The session identifier
@@ -239,8 +236,6 @@ class Session implements CookieEnabledInterface
         $this->sessionCookieSecure = (boolean)$settings['session']['cookie']['secure'];
         $this->sessionCookieHttpOnly = (boolean)$settings['session']['cookie']['httponly'];
         $this->sessionCookieSameSite = $settings['session']['cookie']['samesite'];
-        $this->garbageCollectionProbability = $settings['session']['garbageCollection']['probability'];
-        $this->garbageCollectionMaximumPerRun = $settings['session']['garbageCollection']['maximumPerRun'];
         $this->inactivityTimeout = (integer)$settings['session']['inactivityTimeout'];
     }
 
@@ -621,50 +616,15 @@ class Session implements CookieEnabledInterface
      * Iterates over all existing sessions and removes their data if the inactivity
      * timeout was reached.
      *
-     * @return integer The number of outdated entries removed
+     * @return integer The number of outdated entries removed or NULL if no such information could be determined
+     * @deprecated will be removed with Flow 9, use SessionManager->collectGarbage
      * @throws \Neos\Cache\Exception
      * @throws NotSupportedByBackendException
      * @api
      */
     public function collectGarbage()
     {
-        if ($this->inactivityTimeout === 0) {
-            return 0;
-        }
-        if ($this->metaDataCache->has('_garbage-collection-running')) {
-            return false;
-        }
-
-        $sessionRemovalCount = 0;
-        $this->metaDataCache->set('_garbage-collection-running', true, [], 120);
-
-        foreach ($this->metaDataCache->getIterator() as $sessionIdentifier => $sessionInfo) {
-            if ($sessionIdentifier === '_garbage-collection-running') {
-                continue;
-            }
-            if (!is_array($sessionInfo)) {
-                $sessionInfo = [
-                    'sessionMetaData' => $sessionInfo,
-                    'lastActivityTimestamp' => 0,
-                    'storageIdentifier' => null
-                ];
-                $this->logger->warning('SESSION INFO INVALID: ' . $sessionIdentifier, $sessionInfo + LogEnvironment::fromMethodName(__METHOD__));
-            }
-            $lastActivitySecondsAgo = $this->now - $sessionInfo['lastActivityTimestamp'];
-            if ($lastActivitySecondsAgo > $this->inactivityTimeout) {
-                if ($sessionInfo['storageIdentifier'] !== null) {
-                    $this->storageCache->flushByTag($sessionInfo['storageIdentifier']);
-                    $sessionRemovalCount++;
-                }
-                $this->metaDataCache->remove($sessionIdentifier);
-            }
-            if ($sessionRemovalCount >= $this->garbageCollectionMaximumPerRun) {
-                break;
-            }
-        }
-
-        $this->metaDataCache->remove('_garbage-collection-running');
-        return $sessionRemovalCount;
+        return $this->sessionManager->collectGarbage();
     }
 
     /**
@@ -694,12 +654,6 @@ class Session implements CookieEnabledInterface
                 $this->writeSessionMetaDataCacheEntry();
             }
             $this->started = false;
-
-            $decimals = (integer)strlen(strrchr($this->garbageCollectionProbability, '.')) - 1;
-            $factor = ($decimals > -1) ? $decimals * 10 : 1;
-            if (rand(1, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {
-                $this->collectGarbage();
-            }
         }
     }
 

--- a/Neos.Flow/Classes/Session/SessionInterface.php
+++ b/Neos.Flow/Classes/Session/SessionInterface.php
@@ -163,6 +163,7 @@ interface SessionInterface
      * Remove data of all sessions which are considered to be expired.
      *
      * @return integer The number of outdated entries removed or NULL if no such information could be determined
+     * @deprecated will be removed with Flow 9, use SessionManager->collectGarbage
      */
     public function collectGarbage();
 }

--- a/Neos.Flow/Classes/Session/SessionManager.php
+++ b/Neos.Flow/Classes/Session/SessionManager.php
@@ -11,10 +11,14 @@ namespace Neos\Flow\Session;
  * source code.
  */
 
+use Neos\Cache\Exception\NotSupportedByBackendException;
 use Neos\Flow\Annotations as Flow;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Http\Cookie;
+use Neos\Flow\Log\Utility\LogEnvironment;
+use Neos\Flow\Security\Context;
 use Neos\Flow\Utility\Algorithms;
+use Psr\Log\LoggerInterface;
 
 /**
  * Session Manager
@@ -40,6 +44,38 @@ class SessionManager implements SessionManagerInterface
      * @var VariableFrontend
      */
     protected $metaDataCache;
+
+    /**
+     * Storage cache for by sessions
+     *
+     * @Flow\Inject
+     * @var VariableFrontend
+     */
+    protected $storageCache;
+
+    /**
+     * @var float
+     * @Flow\InjectConfiguration(path="session.garbageCollection.probability")
+     */
+    protected $garbageCollectionProbability;
+
+    /**
+     * @Flow\InjectConfiguration(path="session.garbageCollection.maximumPerRun")
+     * @var integer
+     */
+    protected $garbageCollectionMaximumPerRun;
+
+    /**
+     * @Flow\InjectConfiguration(path="session.inactivityTimeout")
+     * @var integer
+     */
+    protected $inactivityTimeout;
+
+    /**
+     * @Flow\Inject(name="Neos.Flow:SystemLogger")
+     * @var LoggerInterface
+     */
+    protected $logger;
 
     /**
      * Returns the currently active session which stores session data for the
@@ -163,5 +199,75 @@ class SessionManager implements SessionManagerInterface
             $session->destroy($reason);
         }
         return count($sessions);
+    }
+
+    /**
+     * Iterates over all existing sessions and removes their data if the inactivity
+     * timeout was reached.
+     *
+     * @return integer|null The number of outdated entries removed, null in case the garbage-collection was already running
+     * @api
+     */
+    public function collectGarbage(): ?int
+    {
+        if ($this->inactivityTimeout === 0) {
+            return 0;
+        }
+        if ($this->metaDataCache->has('_garbage-collection-running')) {
+            return null;
+        }
+
+        $now = time();
+        $sessionRemovalCount = 0;
+        $this->metaDataCache->set('_garbage-collection-running', true, [], 120);
+
+        foreach ($this->metaDataCache->getIterator() as $sessionIdentifier => $sessionInfo) {
+            if ($sessionIdentifier === '_garbage-collection-running') {
+                continue;
+            }
+            if (!is_array($sessionInfo)) {
+                $sessionInfo = [
+                    'sessionMetaData' => $sessionInfo,
+                    'lastActivityTimestamp' => 0,
+                    'storageIdentifier' => null
+                ];
+                $this->logger->warning('SESSION INFO INVALID: ' . $sessionIdentifier, $sessionInfo + LogEnvironment::fromMethodName(__METHOD__));
+            }
+            $lastActivitySecondsAgo = $now - $sessionInfo['lastActivityTimestamp'];
+            if ($lastActivitySecondsAgo > $this->inactivityTimeout) {
+                if ($sessionInfo['storageIdentifier'] !== null) {
+                    $this->storageCache->flushByTag($sessionInfo['storageIdentifier']);
+                    $sessionRemovalCount++;
+                }
+                $this->metaDataCache->remove($sessionIdentifier);
+            }
+            if ($sessionRemovalCount >= $this->garbageCollectionMaximumPerRun) {
+                break;
+            }
+        }
+
+        $this->metaDataCache->remove('_garbage-collection-running');
+        return $sessionRemovalCount;
+    }
+
+    /**
+     * Shuts down this session
+     *
+     * This method must not be called manually – it is invoked by Flow's object
+     * management.
+     *
+     * @return void
+     * @throws Exception\DataNotSerializableException
+     * @throws Exception\SessionNotStartedException
+     * @throws NotSupportedByBackendException
+     * @throws \Neos\Cache\Exception
+     */
+    public function shutdownObject()
+    {
+        $decimals = strlen(strrchr((string)$this->garbageCollectionProbability, '.')) - 1;
+        $factor = ($decimals > -1) ? $decimals * 10 : 1;
+        if (rand(1, 100 * $factor) <= ($this->garbageCollectionProbability * $factor)) {
+            $this->collectGarbage();
+        }
     }
 }

--- a/Neos.Flow/Classes/Session/SessionManagerInterface.php
+++ b/Neos.Flow/Classes/Session/SessionManagerInterface.php
@@ -69,4 +69,11 @@ interface SessionManagerInterface
      * @api
      */
     public function destroySessionsByTag($tag, $reason = '');
+
+    /**
+     * Remove data of all sessions which are considered to be expired.
+     *
+     * @return integer|null The number of outdated entries removed or NULL if no such information could be determined
+     */
+    public function collectGarbage(): ?int;
 }

--- a/Neos.Flow/Configuration/Objects.yaml
+++ b/Neos.Flow/Configuration/Objects.yaml
@@ -481,7 +481,13 @@ Neos\Flow\Session\SessionManager:
         arguments:
           1:
             value: Flow_Session_MetaData
-
+    storageCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: Flow_Session_Storage
 #
 # Utility
 #

--- a/Neos.Flow/Tests/Unit/Session/SessionManagerTest.php
+++ b/Neos.Flow/Tests/Unit/Session/SessionManagerTest.php
@@ -1,0 +1,224 @@
+<?php
+namespace Neos\Flow\Tests\Unit\Session;
+
+/*
+ * This file is part of the Neos.Flow package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Uri;
+use Neos\Flow\Http\RequestHandler;
+use Neos\Http\Factories\ServerRequestFactory;
+use Neos\Http\Factories\UriFactory;
+use Neos\Flow\Session\Exception\DataNotSerializableException;
+use Neos\Flow\Session\Exception\OperationNotSupportedException;
+use org\bovigo\vfs\vfsStream;
+use Neos\Cache\Backend\FileBackend;
+use Neos\Cache\EnvironmentConfiguration;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Security\Context;
+use Neos\Flow\Session\Exception\SessionNotStartedException;
+use Neos\Flow\Session\Session;
+use Neos\Flow\Session\SessionManager;
+use Neos\Cache\Frontend\VariableFrontend;
+use Neos\Flow\Http\Cookie;
+use Neos\Flow\Security\Authentication\Token\UsernamePassword;
+use Neos\Flow\Security\Authentication\TokenInterface;
+use Neos\Flow\Security\Account;
+use Neos\Flow\Tests\UnitTestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unit tests for the Flow Session implementation
+ */
+class SessionManagerTest extends UnitTestCase
+{
+    /**
+     * @var ServerRequestInterface
+     */
+    protected $httpRequest;
+
+    /**
+     * @var ResponseInterface
+     */
+    protected $httpResponse;
+
+    /**
+     * @var Context|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected $mockSecurityContext;
+
+    /**
+     * @var Bootstrap
+     */
+    protected $mockBootstrap;
+
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected $mockObjectManager;
+
+    /**
+     * @var array
+     */
+    protected $settings = [
+        'session' => [
+            'inactivityTimeout' => 3600,
+            'name' => 'Neos_Flow_Session',
+            'garbageCollection' => [
+                'probability' => 1,
+                'maximumPerRun' => 1000,
+            ],
+            'cookie' => [
+                'lifetime' => 0,
+                'path' => '/',
+                'secure' => false,
+                'httponly' => true,
+                'domain' => null,
+                'samesite' => Cookie::SAMESITE_LAX
+            ]
+        ]
+    ];
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setup();
+
+        vfsStream::setup('Foo');
+
+        $serverRequestFactory = new ServerRequestFactory(new UriFactory());
+        $this->httpRequest = $serverRequestFactory->createServerRequest('GET', new Uri('http://localhost'));
+        $this->httpResponse = new Response();
+
+        $mockRequestHandler = $this->createMock(RequestHandler::class);
+        $mockRequestHandler->expects(self::any())->method('getHttpRequest')->will(self::returnValue($this->httpRequest));
+        $mockRequestHandler->expects(self::any())->method('getHttpResponse')->will(self::returnValue($this->httpResponse));
+
+        $this->mockBootstrap = $this->createMock(Bootstrap::class);
+        $this->mockBootstrap->expects(self::any())->method('getActiveRequestHandler')->will(self::returnValue($mockRequestHandler));
+
+        $this->mockSecurityContext = $this->createMock(Context::class);
+
+        $this->mockObjectManager = $this->createMock(ObjectManagerInterface::class);
+        $this->mockObjectManager->expects(self::any())->method('get')->with(Context::class)->will(self::returnValue($this->mockSecurityContext));
+    }
+
+    /**
+     * @test for #1674
+     */
+    public function garbageCollectionWorksCorrectlyWithInvalidMetadataEntry()
+    {
+        $metaDataCache = $this->createCache('Meta');
+        $metaDataCache->set('foo', null);
+        $storageCache = $this->createCache('Storage');
+
+        $sessionManager = new SessionManager();
+        $this->inject($sessionManager, 'metaDataCache', $metaDataCache);
+        $this->inject($sessionManager, 'storageCache', $storageCache);
+        $this->inject($sessionManager, 'logger', $this->createMock(LoggerInterface::class));
+
+        $this->assertSame(0, $sessionManager->collectGarbage());
+    }
+
+    /**
+     * @test
+     */
+    public function garbageCollectionIsOmittedIfInactivityTimeoutIsSetToZero()
+    {
+        $metaDataCache = $this->createCache('Meta');
+        $storageCache = $this->createCache('Storage');
+
+        $sessionManager = new SessionManager();
+        $this->inject($sessionManager, 'metaDataCache', $metaDataCache);
+        $this->inject($sessionManager, 'storageCache', $storageCache);
+        $this->inject($sessionManager, 'inactivityTimeout', 0);
+
+        self::assertSame(0, $sessionManager->collectGarbage());
+    }
+
+    /**
+     * @test
+     */
+    public function garbageCollectionIsOmittedIfAnotherProcessIsAlreadyRunning()
+    {
+        $metaDataCache = $this->createCache('Meta');
+        $storageCache = $this->createCache('Storage');
+
+        $sessionManager = new SessionManager();
+        $this->inject($sessionManager, 'metaDataCache', $metaDataCache);
+        $this->inject($sessionManager, 'storageCache', $storageCache);
+        $this->inject($sessionManager, 'inactivityTimeout', 5000);
+        $this->inject($sessionManager, 'garbageCollectionProbability', 100);
+
+        // No sessions need to be removed:
+        self::assertSame(0, $sessionManager->collectGarbage());
+
+        $metaDataCache->set('_garbage-collection-running', true, [], 120);
+
+        // Session garbage collection is omitted:
+        self::assertNull($sessionManager->collectGarbage());
+    }
+
+    /**
+     * @test
+     */
+    public function garbageCollectionOnlyRemovesTheDefinedMaximumNumberOfSessions()
+    {
+        $metaDataCache = $this->createCache('Meta');
+        $storageCache = $this->createCache('Storage');
+
+        for ($i = 0; $i < 9; $i++) {
+            $sessionManager = new SessionManager();
+            $this->inject($sessionManager, 'metaDataCache', $metaDataCache);
+            $this->inject($sessionManager, 'storageCache', $storageCache);
+            $this->inject($sessionManager, 'inactivityTimeout', 1000);
+            $this->inject($sessionManager, 'garbageCollectionProbability', 0);
+            $this->inject($sessionManager, 'garbageCollectionMaximumPerRun', 5);
+            $this->inject($sessionManager, 'logger', $this->createMock(LoggerInterface::class));
+
+            $session = new Session();
+            $this->inject($session, 'metaDataCache', $metaDataCache);
+            $this->inject($session, 'storageCache', $storageCache);
+            $this->inject($session, 'objectManager', $this->mockObjectManager);
+            $this->inject($session, 'settings', $this->settings);
+            $session->start();
+            $sessionIdentifier = $session->getId();
+            $session->putData('foo', 'bar');
+            $session->close();
+
+            $sessionInfo = $metaDataCache->get($sessionIdentifier);
+            $sessionInfo['lastActivityTimestamp'] = time() - 4000;
+            $metaDataCache->set($sessionIdentifier, $sessionInfo, ['session'], 0);
+        }
+
+        self::assertLessThanOrEqual(5, $sessionManager->collectGarbage());
+    }
+
+    /**
+     * Creates a cache for testing
+     *
+     * @param string $name
+     * @return VariableFrontend
+     */
+    protected function createCache($name)
+    {
+        $backend = new FileBackend(new EnvironmentConfiguration('Session Testing', 'vfs://Foo/', PHP_MAXPATHLEN));
+        $cache = new VariableFrontend($name, $backend);
+        $cache->initializeObject();
+        $backend->setCache($cache);
+        $cache->flush();
+        return $cache;
+    }
+}


### PR DESCRIPTION
This command will remove session-data and -metadata of outdated sessions identified by lastActivityTimestamp being older than inactivityTimeout This is usually done automatically after shutdown for the percentage of requests specified in the setting `Neos.Flow.session.garbageCollection.probability` Use this command if you need more direct control over the cleanup intervals.

In addition the `collectGarbage` method is moved from the session to the sessionManager. As this was api before a backwards compatible implementation was left behind that can be removed with Flow 9.

**Checklist**

- [ ] Code follows the PSR-2 coding style
- [ ] Tests have been created, run and adjusted as needed
- [ ] The PR is created against the [lowest maintained branch](https://www.neos.io/features/release-roadmap.html)
- [ ] Reviewer - PR Title is brief but complete and starts with `FEATURE|TASK|BUGFIX`
- [ ] Reviewer - The first section explains the change briefly for change-logs
- [ ] Reviewer - Breaking Changes are marked wit `!!!` and have upgrade-instructions
